### PR TITLE
Initialize metrics and experiments in Playground constructor

### DIFF
--- a/lib/vanity/playground.rb
+++ b/lib/vanity/playground.rb
@@ -55,6 +55,8 @@ module Vanity
       @failover_on_datastore_error = false
       self.add_participant_path = DEFAULT_ADD_PARTICIPANT_PATH
       @collecting = !!@options[:collecting]
+      metrics
+      experiments
     end
 
     # Path to load experiment files from.


### PR DESCRIPTION
This commit make sure that all metrics and experiments are initialized with the `Playground` class. Without it experiments will not get tracked in long running processes since the Helper does not initialize them properly and get lazy loaded as the `track!` method is called.
